### PR TITLE
Add check for linux-header in kernel Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Catch all's
+*.cmd
+*.o
+
+# Kernel ignore files/directories
+kernel/.tmp_versions/
+kernel/Module.symvers
+kernel/modules.order
+kernel/nb.ko
+kernel/nb.mod.c
+
+# User ignore files
+user/nanoBench

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -1,5 +1,14 @@
 MODULE_NAME = nb
 
+BUILD_DIR = /lib/modules/$(shell uname -r)/build
+HEADERS_EXIST = $(shell if [ -d "${BUILD_DIR}" ]; then echo "${BUILD_DIR}"; \
+                  else echo ""; fi)
+
+ifneq (${HEADERS_EXIST}, ${BUILD_DIR})
+  $(warning "Check you have linux headers installed")
+  $(error   "${BUILD_DIR} does not exist!")
+endif
+
 SRC := nb_km.c ../common/nanoBench.c
 
 $(MODULE_NAME)-objs += $(SRC:.c=.o)
@@ -17,4 +26,4 @@ all:
 clean:
 	rm -f ../common/*.o ../common/*.ur-safe
 	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean
-	
+


### PR DESCRIPTION
When trying to install this I realised my machine didn't have Linux headers on it!

To save people the 5 minutes of confusion I added a quick check and message for this in the kernel Makefile.

(Also sorry I missed the whitespace change, my editor removes trailing whitespace)