### PR TITLE
Use portable shebang lines

### DIFF
--- a/disable-HT.sh
+++ b/disable-HT.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ "$EUID" -ne 0 ]; then
     echo "This script must be run as root" 1>&2

--- a/enable-HT.sh
+++ b/enable-HT.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ "$EUID" -ne 0 ]; then
     echo "This script must be run as root" 1>&2

--- a/kernel-nanoBench.sh
+++ b/kernel-nanoBench.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ "$EUID" -ne 0 ]; then
     echo "Error: nanoBench requires root privileges"

--- a/nanoBench.sh
+++ b/nanoBench.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ "$EUID" -ne 0 ]; then
     echo "Error: nanoBench requires root privileges" 1>&2

--- a/set-R14-size.sh
+++ b/set-R14-size.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ "$EUID" -ne 0 ]; then
     echo "This script must be run as root" 1>&2

--- a/single-core-mode.sh
+++ b/single-core-mode.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ "$EUID" -ne 0 ]; then
     echo "This script must be run as root" 1>&2


### PR DESCRIPTION
Just a minor thing. As i don't have my bash in /bin/bash, the scripts did not work out of the box on my system. But using `env` is portable across distros.