### PR TITLE
explicitly copy only the .text segment when assembling measured code

### DIFF
--- a/kernelNanoBench.py
+++ b/kernelNanoBench.py
@@ -24,7 +24,7 @@ def assemble(code, objFile, asmFile='/tmp/ramdisk/asm.s'):
 
 def objcopy(sourceFile, targetFile):
    try:
-      subprocess.check_call(['objcopy', sourceFile, '-O', 'binary', targetFile])
+      subprocess.check_call(['objcopy', "-j", ".text", '-O', 'binary', sourceFile, targetFile])
    except subprocess.CalledProcessError as e:
       sys.stderr.write("Error (objcopy): " + str(e))
       exit(1)

--- a/utils.sh
+++ b/utils.sh
@@ -22,6 +22,6 @@ assemble() {
         s/|//g
     " asm-tmp.s
     as asm-tmp.s -o asm-tmp.o || exit
-    objcopy asm-tmp.o -O binary "$filename"
+    objcopy -j .text -O binary asm-tmp.o "$filename"
     rm asm-tmp.*
 }


### PR DESCRIPTION
I updated my Arch Linux machine, and it seems like my `binutils` behavior has changed (from `2.35.1-1` to `2.36.1-2`).
I didn't check the behavior on Ubuntu 18.04 but, either: 
- `as` is now adding a `.note.gnu.property` section to the object file for me, or
- `objcopy -O binary` is no longer sufficient for removing this section

Either way, this is easily fixed by just explicitly specifying that we only want the `.text` segment when assembling with the shell scripts.