### PR TITLE
Propagating return value through runnerscripts

### DIFF
--- a/nanoBench.sh
+++ b/nanoBench.sh
@@ -65,8 +65,10 @@ echo 0 > /proc/sys/kernel/nmi_watchdog
 
 if [ "$debug" = true ]; then
     gdb -ex=run --args user/nanoBench $@
+    return_value=$?
 else
     user/nanoBench $@
+    return_value=$?
 fi
 
 rm -f asm-*.bin
@@ -85,3 +87,4 @@ fi
 if [[ $iTCO_vendor_support_prev_loaded != 0 ]]; then
     modprobe iTCO_vendor_support &>/dev/null
 fi
+exit $return_value


### PR DESCRIPTION
Hello,

during some experiments, I encountered certain system configurations in which nanoBench fails to execute which is indicated by an error message on stdout/stderr. However, I was calling the `nanoBench.sh` from another script in which I could not easily observe this failure because the return code of `nanoBench.sh` is still 0. 
Hence, this minor change makes this easy as the `nanoBench.sh` will just return with non-zero exit code in case nanoBench itself returns with non-zero exit code.