### PR TITLE
fix kernel mode crashing in Ubuntu 22.04

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -15,7 +15,7 @@ $(MODULE_NAME)-objs += $(SRC:.c=.o)
 
 obj-m += $(MODULE_NAME).o
 
-ccflags-y+=-std=gnu99 -Wno-declaration-after-statement -Wno-vla -isystem $(shell $(CC) -print-file-name=include)
+ccflags-y+=-std=gnu99 -Wno-declaration-after-statement -Wno-vla -isystem $(shell $(CC) -print-file-name=include) -mfunction-return=keep
 
 OBJECT_FILES_NON_STANDARD := y
 


### PR DESCRIPTION
While build nanoBench kernel module in Ubuntu 22.04, gcc is with -mfunction-return=thunk-extern as default option. According to chapter 6.1.1 JMP2RET in the following reference:
https://www.amd.com/system/files/documents/\
technical-guidance-for-mitigating-branch-type-confusion.pdf all 'ret' instructions are consolidated into a single piece of code. Instead of functions ending with a 'ret' instruction, they instead end with "jump __x86_return_thunk".

Since a 'jmp' instruction is provided instead of 'ret' at the end of each function, it cause functions like create_runtime_code() copy much more assembler code into runtime_code memory than it should during runtime. Memory protection fault happens finally while running.

To address the above issue, option -mfunction-return=keep is provided for kernel mode to overwrite the gcc default behavior in Ubuntu 22.04. This can ensure function has 'ret' instruction generated.

Signed-off-by: Cathy Zhang <cathy.zhang@intel.com>