### PR TITLE
Add check for selinux status, hint user it might cause the mprotect call failure

### DIFF
--- a/nanoBench.sh
+++ b/nanoBench.sh
@@ -18,6 +18,10 @@ if [ $(cat /sys/devices/system/cpu/smt/active) -ne 0 ]; then
     echo "Note: Hyper-threading is enabled; it can be disabled with \"sudo ./disable-HT.sh\"" >&2
 fi
 
+if [ $(cat /sys/fs/selinux/enforce) -ne 0 ]; then
+    echo "Note: selinux enforcing, mprotect call might fail; it can be disabled with \"sudo setenforce 0\"" >&2
+fi
+
 debug=""
 filter_output="cat"
 


### PR DESCRIPTION
When running the nanobench under CentOS Stream 9, the example 1 will fail with "Error: mprotect failed". The reason is the selinux enforced and the policy prohibited the prot_exec. Thus, add a simple note to remind the user that selinux enforcing which might cause the mprotect call failure. 