### PR TITLE
`native_write_msr` compatibilty for kernel 6.16+

### DIFF
--- a/common/nanoBench.c
+++ b/common/nanoBench.c
@@ -319,7 +319,11 @@ uint64_t read_msr(unsigned int msr) {
 
 void write_msr(unsigned int msr, uint64_t value) {
     #ifdef __KERNEL__
+    #if LINUX_VERSION_CODE >= KERNEL_VERSION(6,16,0)
+        native_write_msr(msr, value);
+    #elif
         native_write_msr(msr, (uint32_t)value, (uint32_t)(value>>32));
+    #endif
     #else
         char cmd[50];
         snprintf(cmd, sizeof(cmd), "wrmsr -p%d %#x %#lx", cpu, msr, value);

--- a/common/nanoBench.h
+++ b/common/nanoBench.h
@@ -15,6 +15,7 @@
 #ifdef __KERNEL__
     #include <linux/module.h>
     #include <linux/sort.h>
+    #include <linux/version.h>
 #else
     #include <inttypes.h>
     #include <stddef.h>


### PR DESCRIPTION
Since kernel 6.16 release, we have the patch [here](https://lore.kernel.org/all/20250427092027.1598740-14-xin@zytor.com/) merged mainline with the commit `785cdec46e92`

It introduces some changes to definition of macros associated with msr operations

Change `native_write_msr` arguments to support this change, along with proper version checks